### PR TITLE
feat: rename package to create-claude-statusline

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,7 +30,7 @@ body:
     id: version
     attributes:
       label: Version
-      description: What version of claude-code-status-line are you running?
+      description: What version of create-claude-statusline are you running?
       options:
         - 0.1.0
       default: 0

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security Issue
-    url: https://github.com/RMNCLDYO/claude-code-status-line/security/policy
+    url: https://github.com/RMNCLDYO/create-claude-statusline/security/policy
     about: Please report security vulnerabilities here
   - name: Community Discussion
-    url: https://github.com/RMNCLDYO/claude-code-status-line/discussions
+    url: https://github.com/RMNCLDYO/create-claude-statusline/discussions
     about: Ask questions and discuss ideas with the community

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,8 +61,8 @@ jobs:
       - name: Create package tarball and set version
         run: |
           npm pack
-          echo "PACKAGE_FILE=$(ls claude-code-status-line-*.tgz | head -1)" >> $GITHUB_ENV
-          echo "VERSION=$(ls claude-code-status-line-*.tgz | head -1 | sed 's/claude-code-status-line-\(.*\)\.tgz/\1/')" >> $GITHUB_ENV
+          echo "PACKAGE_FILE=$(ls create-claude-statusline-*.tgz | head -1)" >> $GITHUB_ENV
+          echo "VERSION=$(ls create-claude-statusline-*.tgz | head -1 | sed 's/create-claude-statusline-\(.*\)\.tgz/\1/')" >> $GITHUB_ENV
         
       - name: Install and verify minisign
         run: |
@@ -88,7 +88,7 @@ jobs:
         run: |
           if [ ! -f minisign.key.skip ]; then
             # Use -W flag to read password from stdin
-            echo "${{ secrets.MINISIGN_PASSPHRASE }}" | minisign -Sm "$PACKAGE_FILE" -s minisign.key -W -t "claude-code-status-line npm package v$VERSION - $(date -u +%Y-%m-%d)"
+            echo "${{ secrets.MINISIGN_PASSPHRASE }}" | minisign -Sm "$PACKAGE_FILE" -s minisign.key -W -t "create-claude-statusline npm package v$VERSION - $(date -u +%Y-%m-%d)"
             echo "✓ Successfully signed package with minisign"
           else
             echo "::warning::Skipping minisign signature generation"
@@ -114,21 +114,21 @@ jobs:
         with:
           path: .
           format: 'spdx-json'
-          output-file: 'claude-code-status-line-${{ env.VERSION }}.sbom.spdx.json'
+          output-file: 'create-claude-statusline-${{ env.VERSION }}.sbom.spdx.json'
           
       - name: Generate CycloneDX JSON SBOM
         uses: anchore/sbom-action@e11c554f704a0b820cbf8c51673f6945e0731532 # v0.20.0
         with:
           path: .
           format: 'cyclonedx-json'
-          output-file: 'claude-code-status-line-${{ env.VERSION }}.sbom.cyclonedx.json'
+          output-file: 'create-claude-statusline-${{ env.VERSION }}.sbom.cyclonedx.json'
           
       - name: Generate CycloneDX XML SBOM
         uses: anchore/sbom-action@e11c554f704a0b820cbf8c51673f6945e0731532 # v0.20.0
         with:
           path: .
           format: 'cyclonedx-xml'
-          output-file: 'claude-code-status-line-${{ env.VERSION }}.sbom.cyclonedx.xml'
+          output-file: 'create-claude-statusline-${{ env.VERSION }}.sbom.cyclonedx.xml'
           
       - name: Generate legacy SPDX with Microsoft tool
         run: |
@@ -139,8 +139,8 @@ jobs:
           chmod +x sbom-tool-linux-x64
           
           # Generate Microsoft SBOM
-          ./sbom-tool-linux-x64 generate -b . -bc . -pn claude-code-status-line -pv $VERSION -ps RMNCLDYO -nsb https://github.com/RMNCLDYO/claude-code-status-line
-          mv _manifest/spdx_2.2/manifest.spdx.json "claude-code-status-line-$VERSION.ms-spdx.json"
+          ./sbom-tool-linux-x64 generate -b . -bc . -pn create-claude-statusline -pv $VERSION -ps RMNCLDYO -nsb https://github.com/RMNCLDYO/create-claude-statusline
+          mv _manifest/spdx_2.2/manifest.spdx.json "create-claude-statusline-$VERSION.ms-spdx.json"
           
           # Cleanup
           rm -rf _manifest sbom-tool-linux-x64
@@ -148,11 +148,11 @@ jobs:
       - name: Sign all SBOMs and attestations
         run: |
           # Sign all SBOM files with both minisign and GPG (if keys available)
-          for sbom in claude-code-status-line-$VERSION.sbom.* claude-code-status-line-$VERSION.ms-spdx.json; do
+          for sbom in create-claude-statusline-$VERSION.sbom.* create-claude-statusline-$VERSION.ms-spdx.json; do
             if [ -f "$sbom" ]; then
               echo "Signing $sbom"
               if [ ! -f minisign.key.skip ]; then
-                echo "${{ secrets.MINISIGN_PASSPHRASE }}" | minisign -Sm "$sbom" -s minisign.key -W -t "SBOM for claude-code-status-line v$VERSION"
+                echo "${{ secrets.MINISIGN_PASSPHRASE }}" | minisign -Sm "$sbom" -s minisign.key -W -t "SBOM for create-claude-statusline v$VERSION"
               fi
               gpg --armor --detach-sign --output "$sbom.asc" "$sbom"
             fi
@@ -179,18 +179,10 @@ jobs:
           
       - name: Publish to GitHub Packages
         run: |
-          # Update package name for GitHub Packages (scoped)
-          npm pkg set name="@rmncldyo/claude-code-status-line"
-          
-          # Publish to GitHub Packages with provenance
+          # Package already has scoped name, publish directly
           npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
-      - name: Restore original package name
-        run: |
-          # Restore original package name for npm registry
-          npm pkg set name="claude-code-status-line"
           
       - name: Create comprehensive GitHub Release
         uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.3.2
@@ -202,12 +194,12 @@ jobs:
             
             **Install from npm:**
             ```bash
-            npm install -g claude-code-status-line@${{ github.ref_name }}
+            npm install -g create-claude-statusline@${{ github.ref_name }}
             ```
             
             **Install from GitHub Packages:**
             ```bash
-            npm install -g @rmncldyo/claude-code-status-line@${{ github.ref_name }} --registry=https://npm.pkg.github.com
+            npm install -g @rmncldyo/create-claude-statusline@${{ github.ref_name }} --registry=https://npm.pkg.github.com
             ```
             
             ## 🔐 Security & Verification
@@ -218,10 +210,10 @@ jobs:
             curl -O https://raw.githubusercontent.com/${{ github.repository }}/main/minisign.pub
             
             # Verify minisign signature (recommended)
-            minisign -Vm claude-code-status-line-${{ github.ref_name }}.tgz -p minisign.pub
+            minisign -Vm create-claude-statusline-${{ github.ref_name }}.tgz -p minisign.pub
             
             # Verify GPG signature
-            gpg --verify claude-code-status-line-${{ github.ref_name }}.tgz.asc claude-code-status-line-${{ github.ref_name }}.tgz
+            gpg --verify create-claude-statusline-${{ github.ref_name }}.tgz.asc create-claude-statusline-${{ github.ref_name }}.tgz
             ```
             
             **Supply Chain Attestations:**
@@ -235,10 +227,10 @@ jobs:
             
             | Format | File | Signatures |
             |--------|------|------------|
-            | **SPDX 2.3** | `claude-code-status-line-${{ github.ref_name }}.sbom.spdx.json` | `.minisig`, `.asc` |
-            | **CycloneDX** | `claude-code-status-line-${{ github.ref_name }}.sbom.cyclonedx.json` | `.minisig`, `.asc` |
-            | **CycloneDX XML** | `claude-code-status-line-${{ github.ref_name }}.sbom.cyclonedx.xml` | `.minisig`, `.asc` |
-            | **Microsoft SPDX** | `claude-code-status-line-${{ github.ref_name }}.ms-spdx.json` | `.minisig`, `.asc` |
+            | **SPDX 2.3** | `create-claude-statusline-${{ github.ref_name }}.sbom.spdx.json` | `.minisig`, `.asc` |
+            | **CycloneDX** | `create-claude-statusline-${{ github.ref_name }}.sbom.cyclonedx.json` | `.minisig`, `.asc` |
+            | **CycloneDX XML** | `create-claude-statusline-${{ github.ref_name }}.sbom.cyclonedx.xml` | `.minisig`, `.asc` |
+            | **Microsoft SPDX** | `create-claude-statusline-${{ github.ref_name }}.ms-spdx.json` | `.minisig`, `.asc` |
             
             ## 🛡️ Security Standards Compliance
             
@@ -249,10 +241,10 @@ jobs:
             
             ---
             
-            **Full Changelog**: [CHANGELOG.md](https://github.com/RMNCLDYO/claude-code-status-line/blob/main/CHANGELOG.md)
+            **Full Changelog**: [CHANGELOG.md](https://github.com/RMNCLDYO/create-claude-statusline/blob/main/CHANGELOG.md)
           files: |
-            claude-code-status-line-*.tgz
-            claude-code-status-line-*.tgz.minisig
-            claude-code-status-line-*.tgz.asc
-            claude-code-status-line-*.sbom.*
-            claude-code-status-line-*.ms-spdx.json*
+            create-claude-statusline-*.tgz
+            create-claude-statusline-*.tgz.minisig
+            create-claude-statusline-*.tgz.asc
+            create-claude-statusline-*.sbom.*
+            create-claude-statusline-*.ms-spdx.json*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,4 +15,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Statusline scripts for project and Git status
 - TypeScript support with strict configuration
 
-[0.1.0]: https://github.com/RMNCLDYO/claude-code-status-line/releases/tag/v0.1.0
+[0.1.0]: https://github.com/RMNCLDYO/create-claude-statusline/releases/tag/v0.1.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,15 +1,15 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata from this file."
 type: software
-title: "claude-code-status-line"
+title: "create-claude-statusline"
 abstract: "Beautiful, customizable status line for Claude Code. Shows project info, git status, and model context at a glance."
 authors:
   - given-names: "RMNCLDYO"
     email: "hi@rmncldyo.com"
     orcid: "https://orcid.org/0009-0008-2148-3095"
-repository-code: "https://github.com/RMNCLDYO/claude-code-status-line"
-url: "https://github.com/RMNCLDYO/claude-code-status-line"
-repository-artifact: "https://www.npmjs.com/package/claude-code-status-line"
+repository-code: "https://github.com/RMNCLDYO/create-claude-statusline"
+url: "https://github.com/RMNCLDYO/create-claude-statusline"
+repository-artifact: "https://www.npmjs.com/package/create-claude-statusline"
 keywords:
   - "claude"
   - "claude-code" 
@@ -26,6 +26,6 @@ keywords:
   - "typescript"
   - "npm"
 license: MIT
-license-url: "https://github.com/RMNCLDYO/claude-code-status-line/blob/main/LICENSE"
+license-url: "https://github.com/RMNCLDYO/create-claude-statusline/blob/main/LICENSE"
 version: "0.1.0"
 date-released: "2025-09-10"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-# CODEOWNERS for claude-code-status-line
+# CODEOWNERS for create-claude-statusline
 # This file defines code ownership for automatic review requests
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,8 @@
 ## Quick Start
 
 ```bash
-git clone https://github.com/RMNCLDYO/claude-code-status-line.git
-cd claude-code-status-line
+git clone https://github.com/RMNCLDYO/create-claude-statusline.git
+cd create-claude-statusline
 npm install
 npm test
 ```
@@ -54,7 +54,7 @@ npm run lint    # TypeScript strict mode
 
 ## Issues
 
-Found a bug? [Open an issue](https://github.com/RMNCLDYO/claude-code-status-line/issues) with:
+Found a bug? [Open an issue](https://github.com/RMNCLDYO/create-claude-statusline/issues) with:
 - Node version
 - Operating system
 - Error message

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Beautiful, customizable status line for Claude Code. Shows project info, git status, and model context at a glance.
 
-[![version](https://img.shields.io/npm/v/claude-code-status-line.svg?label=version&color=brightgreen)](https://www.npmjs.com/package/claude-code-status-line)
-[![downloads](https://img.shields.io/npm/dm/claude-code-status-line.svg?label=downloads&color=blue)](https://www.npmjs.com/package/claude-code-status-line)
-[![package size](https://img.shields.io/npm/unpacked-size/claude-code-status-line?label=package%20size&color=yellow)](https://www.npmjs.com/package/claude-code-status-line)
+[![version](https://img.shields.io/npm/v/create-claude-statusline.svg?label=version&color=brightgreen)](https://www.npmjs.com/package/create-claude-statusline)
+[![downloads](https://img.shields.io/npm/dm/create-claude-statusline.svg?label=downloads&color=blue)](https://www.npmjs.com/package/create-claude-statusline)
+[![package size](https://img.shields.io/npm/unpacked-size/create-claude-statusline?label=package%20size&color=yellow)](https://www.npmjs.com/package/create-claude-statusline)
 [![license](https://img.shields.io/badge/license-MIT-red.svg)](https://opensource.org/licenses/MIT)
 
 ## What is this?
@@ -20,7 +20,7 @@ A lightweight status line for Claude Code that displays contextual information a
 ## Quick Start
 
 ```bash
-npx claude-code-status-line
+npx create-claude-statusline
 ```
 
 *Adds status line config files to your project. ZERO dependencies in your project.*
@@ -38,7 +38,7 @@ The installation adds these files to your project:
     └── statusline-detect.cjs    # Framework detection
 ```
 
-**Safety:** If you already have a `.claude` directory, it will be backed up to `.claude-code-status-line-backup-[timestamp]` before installation. Your existing configuration is never lost.
+**Safety:** If you already have a `.claude` directory, it will be backed up to `.create-claude-statusline-backup-[timestamp]` before installation. Your existing configuration is never lost.
 
 ## Installation Safety
 
@@ -53,17 +53,17 @@ The installation adds these files to your project:
 ### Via Package Managers
 
 ```bash
-npm install -g claude-code-status-line    # Install globally
-npx claude-code-status-line               # Run directly
-pnpm dlx claude-code-status-line          # pnpm
-bunx claude-code-status-line              # bun
+npm install -g create-claude-statusline    # Install globally
+npx create-claude-statusline               # Run directly
+pnpm dlx create-claude-statusline          # pnpm
+bunx create-claude-statusline              # bun
 ```
 
 ### Flags
 
 ```bash
-npx claude-code-status-line --dry-run     # Preview what will be installed
-npx claude-code-status-line --help        # Show all options
+npx create-claude-statusline --dry-run     # Preview what will be installed
+npx create-claude-statusline --help        # Show all options
 ```
 
 ### Shortcuts
@@ -71,8 +71,8 @@ npx claude-code-status-line --help        # Show all options
 Once installed globally:
 
 ```bash
-claude-code-status-line                   # Full command
-ccsl                                       # Short alias (Claude Code Status Line)
+create-claude-statusline                   # Full command
+ccs                                        # Short alias (Create Claude Statusline)
 ```
 
 ## What it looks like
@@ -135,11 +135,11 @@ The status line is fully customizable. After installation, you can modify the sc
 ### As a Library
 
 ```bash
-npm install claude-code-status-line
+npm install create-claude-statusline
 ```
 
 ```javascript
-import { init } from 'claude-code-status-line';
+import { init } from 'create-claude-statusline';
 
 // Initialize status line in a project
 const result = await init('/path/to/project', {
@@ -238,17 +238,17 @@ To restore your previous configuration from backup:
 
 ```bash
 # List available backups
-ls -la .claude-code-status-line-backup-*
+ls -la .create-claude-statusline-backup-*
 
 # Restore from a backup (replace timestamp with actual)
 rm -rf .claude
-mv .claude-code-status-line-backup-[timestamp] .claude
+mv .create-claude-statusline-backup-[timestamp] .claude
 ```
 
 To clean up all backup directories:
 
 ```bash
-rm -rf .claude-code-status-line-backup-*
+rm -rf .create-claude-statusline-backup-*
 ```
 
 ## FAQ
@@ -263,7 +263,7 @@ A: Yes! All scripts in `.claude/scripts/` can be modified to suit your needs.
 A: Yes, each run creates a new timestamped backup of your existing configuration.
 
 **Q: Where are backups stored?**
-A: Backups are stored in your project directory as `.claude-code-status-line-backup-[timestamp]`.
+A: Backups are stored in your project directory as `.create-claude-statusline-backup-[timestamp]`.
 
 **Q: What if the installation fails?**
 A: The installer uses transactions with automatic rollback. If anything fails, your original configuration is restored.
@@ -290,8 +290,8 @@ All participants are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md
 
 ## Support
 
-- **Issues**: [GitHub Issues](https://github.com/RMNCLDYO/claude-code-status-line/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/RMNCLDYO/claude-code-status-line/discussions)
+- **Issues**: [GitHub Issues](https://github.com/RMNCLDYO/create-claude-statusline/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/RMNCLDYO/create-claude-statusline/discussions)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,35 +1,71 @@
-# Claude Code Status Line
+# create-claude-statusline
 
-Beautiful, customizable status line for Claude Code. Shows project info, git status, and model context at a glance.
+Beautiful status line for Claude Code. Shows git status, model context, and project info at a glance.
 
 [![version](https://img.shields.io/npm/v/create-claude-statusline.svg?label=version&color=brightgreen)](https://www.npmjs.com/package/create-claude-statusline)
 [![downloads](https://img.shields.io/npm/dm/create-claude-statusline.svg?label=downloads&color=blue)](https://www.npmjs.com/package/create-claude-statusline)
 [![package size](https://img.shields.io/npm/unpacked-size/create-claude-statusline?label=package%20size&color=yellow)](https://www.npmjs.com/package/create-claude-statusline)
 [![license](https://img.shields.io/badge/license-MIT-red.svg)](https://opensource.org/licenses/MIT)
 
-## What is this?
-
-A lightweight status line for Claude Code that displays contextual information about your coding session. Similar to terminal prompts like Oh-my-zsh, it shows:
-
-- 📁 Current project and directory
-- 🌿 Git branch and status (ahead/behind, staged, untracked)
-- ⚡ Active model (Opus, Sonnet, etc.)
-- 🔧 Detected framework and runtime
-- 📊 Real-time updates as you work
-
 ## Quick Start
 
 ```bash
-npx create-claude-statusline
+npm create claude-statusline
 ```
 
-*Adds status line config files to your project. ZERO dependencies in your project.*
+*Adds a beautiful status line to your Claude Code. ZERO dependencies in your project.*
+
+## What You Get
+
+```
+[ ◈ my-project on ⎇ main ↑ 2 / ? 3 via ◉ React (node) | ⚡ Opus ]
+```
+
+This tells you:
+- **Project**: `my-project`
+- **Git branch**: `main` with 2 commits ahead, 3 untracked files
+- **Framework**: React (running on Node.js)
+- **Model**: Opus
+
+## Installation
+
+```bash
+npm create claude-statusline     # npm
+npx create-claude-statusline     # npx
+pnpm dlx create-claude-statusline # pnpm  
+bunx create-claude-statusline    # bun
+```
+
+### Options
+
+```bash
+npm create claude-statusline --dry-run  # Preview what will be installed
+npm create claude-statusline --help     # Show all options
+```
+
+### Global Install
+
+```bash
+npm install -g create-claude-statusline
+create-claude-statusline  # Run from anywhere
+ccs                       # Short alias
+```
+
+## Features
+
+✨ **Smart Detection** - Automatically detects your framework, runtime, and package manager
+
+🎨 **Customizable** - Modify colors, icons, and sections to match your style
+
+⚡ **Fast** - Caches git operations for sub-100ms updates
+
+🔒 **Safe** - Creates automatic backups before making any changes
+
+📦 **Zero Dependencies** - No runtime dependencies in your project
 
 ## What Gets Installed
 
-The installation adds these files to your project:
-
-```bash
+```
 .claude/
 ├── settings.local.json          # Status line configuration
 └── scripts/
@@ -38,266 +74,95 @@ The installation adds these files to your project:
     └── statusline-detect.cjs    # Framework detection
 ```
 
-**Safety:** If you already have a `.claude` directory, it will be backed up to `.create-claude-statusline-backup-[timestamp]` before installation. Your existing configuration is never lost.
-
-## Installation Safety
-
-- ✅ **Non-destructive**: Creates automatic backups of existing `.claude` directories
-- ✅ **Idempotent**: Safe to run multiple times
-- ✅ **Reversible**: Backup directories preserve your original configuration
-- ✅ **Project-only**: Only modifies files in your current project directory
-- ✅ **Verified backups**: Uses SHA256 checksums to ensure backup integrity
-
-## Installation Options
-
-### Via Package Managers
-
-```bash
-npm install -g create-claude-statusline    # Install globally
-npx create-claude-statusline               # Run directly
-pnpm dlx create-claude-statusline          # pnpm
-bunx create-claude-statusline              # bun
-```
-
-### Flags
-
-```bash
-npx create-claude-statusline --dry-run     # Preview what will be installed
-npx create-claude-statusline --help        # Show all options
-```
-
-### Shortcuts
-
-Once installed globally:
-
-```bash
-create-claude-statusline                   # Full command
-ccs                                        # Short alias (Create Claude Statusline)
-```
-
-## What it looks like
-
-```bash
-[ ◈ my-project on ⎇ main ↑ 2 / ? 3 via ◉ React (node) | ⚡ Opus ]
-```
-
-This tells you:
-
-- **Project**: `my-project`
-- **Git branch**: `main` with 2 commits ahead, 3 untracked files
-- **Framework**: React (running on Node.js)
-- **Model**: Opus
-
-## Features
-
-### Smart Detection
-
-Automatically detects:
-
-- **Frameworks**: Next.js, React, Vue, Angular, Svelte, Express, NestJS, and more
-- **Runtimes**: Node.js, Python, Rust, Go, Java, TypeScript, Bun, C/C++
-- **Git status**: Branch, commits ahead/behind, staged/untracked changes
-- **Package managers**: npm, yarn, pnpm, bun
-
-### Real-time Updates
-
-The status line updates automatically when:
-
-- You switch directories
-- Git status changes
-- Model changes
-- Files are modified
-
-### Lightweight & Fast
-
-- No runtime dependencies
-- Caches git operations for performance
-- Sub-100ms update times
-- No background processes
-
 ## Customization
 
-The status line is fully customizable. After installation, you can modify the scripts in `.claude/scripts/`:
+Edit `.claude/scripts/statusline.cjs` to customize:
 
-### File Structure
-
-```bash
-.claude/
-├── settings.local.json          # Configuration
-└── scripts/
-    ├── statusline.cjs           # Main logic
-    ├── statusline-git.cjs       # Git integration
-    └── statusline-detect.cjs    # Framework detection
-```
-
-## Programmatic Usage
-
-### As a Library
-
-```bash
-npm install create-claude-statusline
-```
-
+### Colors
 ```javascript
-import { init } from 'create-claude-statusline';
-
-// Initialize status line in a project
-const result = await init('/path/to/project', {
-  dryRun: false  // Set to true for preview
-});
-
-console.log(result.message);
+COLORS: {
+  PROJECT: '\x1b[38;5;117m',  // Light blue
+  BRANCH: '\x1b[38;5;156m',   // Light green
+  MODEL: '\x1b[38;5;93m',     // Purple
+}
 ```
 
-### API
-
-#### `init(projectPath, options)`
-
-Initializes the status line in the specified project.
-
-**Parameters:**
-
-- `projectPath` (string): Path to the project directory
-- `options` (object):
-  - `dryRun` (boolean): Preview mode without making changes
-
-**Returns:** `Promise<InitResult>`
-
-- `success` (boolean): Whether initialization succeeded
-- `filesCreated` (number): Number of files created
-- `message` (string): Result message
-
-## How it Works
-
-1. **Installation**: Copies status line scripts to `.claude/scripts/`
-2. **Configuration**: Adds status line config to `.claude/settings.local.json`
-3. **Execution**: Claude Code calls your script when updating the interface
-4. **Input**: Script receives session context as JSON via stdin
-5. **Output**: Returns formatted text with ANSI colors to stdout
-
-## Requirements
-
-- Node.js 18.0.0 or higher (for installation and runtime)
-- Claude Code CLI
-- Git (optional, for git status features)
-
-## Troubleshooting
-
-### Status line not appearing?
-
-1. **Check installation**:
-
-```bash
-ls -la .claude/scripts/statusline.cjs
+### Icons
+```javascript
+ICONS: {
+  PROJECT: '◈',
+  BRANCH: '⎇',
+  MODEL: '⚡',
+  GIT_AHEAD: '↑',
+  GIT_BEHIND: '↓',
+}
 ```
 
-2. **Verify executable**:
+## Safety
 
+If you already have a `.claude` directory, it will be backed up to `.create-claude-statusline-backup-[timestamp]` before installation.
+
+### Restore from Backup
 ```bash
-chmod +x .claude/scripts/statusline.cjs
-```
-
-3. **Test manually**:
-
-```bash
-echo '{"model":{"display_name":"Test"}}' | node .claude/scripts/statusline.cjs
-```
-
-4. **Check configuration**:
-
-```bash
-cat .claude/settings.local.json | grep statusLine
-```
-
-### Git info not showing?
-
-- Ensure you're in a git repository
-- Check that git is installed: `which git`
-- Verify git commands work: `git status`
-
-### Performance issues?
-
-- Check git repository size
-- Reduce git operations frequency in config
-- Disable unused features
-
-## Uninstalling
-
-To remove the status line from a project:
-
-```bash
-# Remove the status line files
-rm -rf .claude/scripts/statusline*.cjs
-
-# Remove configuration from settings
-nano .claude/settings.local.json
-# Delete the "statusLine" section
-```
-
-To restore your previous configuration from backup:
-
-```bash
-# List available backups
+# List backups
 ls -la .create-claude-statusline-backup-*
 
-# Restore from a backup (replace timestamp with actual)
+# Restore
 rm -rf .claude
 mv .create-claude-statusline-backup-[timestamp] .claude
 ```
 
-To clean up all backup directories:
+## Uninstall
 
 ```bash
-rm -rf .create-claude-statusline-backup-*
+# Remove status line configuration
+rm -rf .claude/scripts/statusline*.cjs
+
+# Edit .claude/settings.local.json and remove the "statusLine" section
 ```
 
-## FAQ
+## Programmatic Usage
 
-**Q: Will this overwrite my existing Claude Code configuration?**
-A: No. If you have an existing `.claude` directory, it will be backed up automatically before installation.
+```javascript
+import { init } from 'create-claude-statusline';
 
-**Q: Can I customize the status line after installation?**
-A: Yes! All scripts in `.claude/scripts/` can be modified to suit your needs.
+await init('/path/to/project', {
+  dryRun: false  // Set to true for preview
+});
+```
 
-**Q: Is it safe to run the installer multiple times?**
-A: Yes, each run creates a new timestamped backup of your existing configuration.
+## Requirements
 
-**Q: Where are backups stored?**
-A: Backups are stored in your project directory as `.create-claude-statusline-backup-[timestamp]`.
+- Node.js 18+
+- [Claude Code](https://claude.ai/code)
+- Git (optional, for git status features)
 
-**Q: What if the installation fails?**
-A: The installer uses transactions with automatic rollback. If anything fails, your original configuration is restored.
+## Troubleshooting
 
-**Q: Can I use this in multiple projects?**
-A: Yes! Run the installer in each project where you want the status line.
+**Status line not showing?**
+```bash
+# Check installation
+ls -la .claude/scripts/statusline.cjs
 
-**Q: Does this work with existing Claude Code agents and commands?**
-A: Yes, the status line is independent and won't interfere with other Claude Code features.
+# Test manually
+echo '{"model":{"display_name":"Test"}}' | node .claude/scripts/statusline.cjs
+```
 
-## Contributing
+**Git info missing?**
+- Ensure you're in a git repository
+- Check that `git status` works
 
-We welcome contributions! Areas where you can help:
+## Links
 
-- Add more framework detections
-- Improve performance
-- Add new status sections
-- Improve documentation
-- Add tests
-
-Please check our [Contributing Guide](CONTRIBUTING.md) for details.
-
-All participants are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
-
-## Support
-
-- **Issues**: [GitHub Issues](https://github.com/RMNCLDYO/create-claude-statusline/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/RMNCLDYO/create-claude-statusline/discussions)
+[**Issues**](https://github.com/RMNCLDYO/create-claude-statusline/issues) • 
+[**Discussions**](https://github.com/RMNCLDYO/create-claude-statusline/discussions) • 
+[**Changelog**](CHANGELOG.md) • 
+[**Security**](SECURITY.md)
 
 ## License
 
 MIT © [RMNCLDYO](https://github.com/RMNCLDYO)
 
-## Related Projects
+---
 
-- [Claude Code](https://claude.ai/code) - The official Claude coding assistant
-- [create-claude](https://github.com/RMNCLDYO/create-claude) - Full Claude Code project setup
+Originally extracted from [create-claude](https://github.com/RMNCLDYO/create-claude) due to popular demand for the standalone status line feature.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,13 +1,13 @@
 # Support
 
-Thanks for using claude-code-status-line! This document explains how to get help with the project.
+Thanks for using create-claude-statusline! This document explains how to get help with the project.
 
 ## Getting Help
 
 ### Community Support
 
-- **GitHub Discussions**: Ask questions and discuss ideas with the community at [GitHub Discussions](https://github.com/RMNCLDYO/claude-code-status-line/discussions)
-- **Issues**: Report bugs or request features through [GitHub Issues](https://github.com/RMNCLDYO/claude-code-status-line/issues)
+- **GitHub Discussions**: Ask questions and discuss ideas with the community at [GitHub Discussions](https://github.com/RMNCLDYO/create-claude-statusline/discussions)
+- **Issues**: Report bugs or request features through [GitHub Issues](https://github.com/RMNCLDYO/create-claude-statusline/issues)
 
 ### Documentation
 
@@ -41,7 +41,7 @@ Before creating an issue, please:
    - Operating system
    - Node.js version
    - npm/yarn/pnpm version
-   - claude-code-status-line version
+   - create-claude-statusline version
 
 ## Commercial Support
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "claude-code-status-line",
+  "name": "create-claude-statusline",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "claude-code-status-line",
+      "name": "create-claude-statusline",
       "version": "0.1.0",
       "cpu": [
         "x64",
@@ -19,7 +19,7 @@
       ],
       "bin": {
         "ccsl": "dist/cli.js",
-        "claude-code-status-line": "dist/cli.js"
+        "create-claude-statusline": "dist/cli.js"
       },
       "devDependencies": {
         "@types/node": "^24.3.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "claude-code-status-line",
+  "name": "create-claude-statusline",
   "version": "0.1.0",
   "description": "Beautiful, customizable status line for Claude Code. Shows project info, git status, and model context at a glance.",
   "type": "module",
@@ -16,8 +16,8 @@
     "./cli": "./dist/cli.js"
   },
   "bin": {
-    "claude-code-status-line": "dist/cli.js",
-    "ccsl": "dist/cli.js"
+    "create-claude-statusline": "dist/cli.js",
+    "ccs": "dist/cli.js"
   },
   "files": [
     "dist",
@@ -74,12 +74,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/RMNCLDYO/claude-code-status-line.git"
+    "url": "git+https://github.com/RMNCLDYO/create-claude-statusline.git"
   },
   "bugs": {
-    "url": "https://github.com/RMNCLDYO/claude-code-status-line/issues"
+    "url": "https://github.com/RMNCLDYO/create-claude-statusline/issues"
   },
-  "homepage": "https://github.com/RMNCLDYO/claude-code-status-line#readme",
+  "homepage": "https://github.com/RMNCLDYO/create-claude-statusline#readme",
   "engines": {
     "node": ">=18.0.0",
     "npm": ">=9.0.0"

--- a/src/atomic.ts
+++ b/src/atomic.ts
@@ -230,7 +230,7 @@ export class TransactionLog {
   private backupDir: string;
   
   constructor() {
-    this.backupDir = join(tmpdir(), `.claude-code-status-line-tx-${Date.now()}-${randomBytes(4).toString('hex')}`);
+    this.backupDir = join(tmpdir(), `.create-claude-statusline-tx-${Date.now()}-${randomBytes(4).toString('hex')}`);
   }
   
   async init(): Promise<void> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -73,10 +73,10 @@ async function runInit(options: { dryRun?: boolean; directory?: string | undefin
 }
 
 function showHelp(): void {
-  console.log(`claude-code-status-line - Beautiful status line for Claude Code`);
+  console.log(`create-claude-statusline - Beautiful status line for Claude Code`);
   console.log(``);
   console.log(`USAGE:`);
-  console.log(`  claude-code-status-line [directory] [OPTIONS]`);
+  console.log(`  create-claude-statusline [directory] [OPTIONS]`);
   console.log(`  ccsl [directory] [OPTIONS]`);
   console.log(``);
   console.log(`DESCRIPTION:`);
@@ -93,9 +93,9 @@ function showHelp(): void {
   console.log(`  --dry-run      Show what would be done without making changes`);
   console.log(``);
   console.log(`EXAMPLES:`);
-  console.log(`  claude-code-status-line              # Setup in current directory`);
-  console.log(`  claude-code-status-line my-project   # Setup in ./my-project directory`);
-  console.log(`  claude-code-status-line --dry-run    # Preview changes without applying`);
+  console.log(`  create-claude-statusline              # Setup in current directory`);
+  console.log(`  create-claude-statusline my-project   # Setup in ./my-project directory`);
+  console.log(`  create-claude-statusline --dry-run    # Preview changes without applying`);
 }
 
 function checkNodeVersion(): void {

--- a/src/files.ts
+++ b/src/files.ts
@@ -65,7 +65,7 @@ function getSourceDir(): string {
 
 async function createBackupDir(projectPath: string): Promise<string> {
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-  const backupDir = join(projectPath, `.claude-code-status-line-backup-${timestamp}`);
+  const backupDir = join(projectPath, `.create-claude-statusline-backup-${timestamp}`);
   
   await withRetry(
     async () => await fs.mkdir(backupDir, { recursive: true }),

--- a/src/init.ts
+++ b/src/init.ts
@@ -66,7 +66,7 @@ async function validateSkelFiles(): Promise<void> {
     throw new InitError(
       `PACKAGE CORRUPTED: Skeleton files missing\n` +
       `Expected: ${skelDir}\n` +
-      `Action: Reinstall with 'npm install -g claude-code-status-line'`,
+      `Action: Reinstall with 'npm install -g create-claude-statusline'`,
       ErrorCode.SKELETON_FILES_MISSING
     );
   }
@@ -92,7 +92,7 @@ async function validateSkelFiles(): Promise<void> {
     throw new InitError(
       `PACKAGE CORRUPTED: Required files missing\n` +
       `Missing: ${missingFiles.join(', ')}\n` +
-      `Action: Reinstall with 'npm install -g claude-code-status-line'`,
+      `Action: Reinstall with 'npm install -g create-claude-statusline'`,
       ErrorCode.SKELETON_FILES_MISSING
     );
   }


### PR DESCRIPTION
## Summary
- Renamed package from `claude-code-status-line` to `create-claude-statusline`
- Simplified README to focus only on status line functionality
- Updated all references across the codebase

## Why this change?
- npm rejected the original name as too similar to existing `claude-code-statusline`
- New name follows npm convention for setup/installer packages (`create-*` pattern)
- More discoverable and clear about its purpose

## Changes Made
- Updated package.json with new name and bin commands
- Updated all GitHub workflows for new package name format
- Simplified README from 300+ lines to ~170 lines
- Removed references to features not in this package (agents, commands, hooks)
- Updated all documentation files with new repository URLs

## Testing
- [x] Package builds successfully
- [x] TypeScript validation passes
- [x] All file references updated

## Review Notes
Ready for v0.1.0 release once merged!